### PR TITLE
CustomMerch - setting exchange from json

### DIFF
--- a/CustomMerch/Main.cs
+++ b/CustomMerch/Main.cs
@@ -61,7 +61,29 @@ namespace CustomMerch
                             for (int i = 0; i < jsonRoot.Count; i++)
                             {
                                 JSONNode jsonNode = jsonRoot[i];
-                                storeItems.Add(new StoreItem(jsonNode["ID"].AsInt, productIds++, jsonNode["count"].AsInt, jsonNode["currency"].AsInt, jsonNode["requireMission"], jsonNode["storeId"].AsInt, jsonNode["chance"].AsFloat));
+
+                                int count = 1;
+                                if (jsonNode["count"] != null)
+                                    count = jsonNode["count"].AsInt;
+
+                                int currency = -1;
+                                if (jsonNode["currency"] != null)
+                                    currency = jsonNode["currency"].AsInt;
+
+                                string exchange = "-1";
+                                if (jsonNode["exchange"] != null)
+                                    exchange = jsonNode["exchange"];
+
+                                string requireMission = "-1";
+                                if (jsonNode["requireMission"] != null)
+                                    requireMission = jsonNode["requireMission"];
+
+                                float chance = 1f;
+                                if (jsonNode["chance"] != null)
+                                    chance = jsonNode["chance"].AsFloat;
+
+                                Dbgl($"add from json: {jsonNode["ID"]} as productIds={productIds} to store={jsonNode["storeId"]} with count={count} price {exchange} @ {currency}, chance={chance}, requireMission={requireMission}");
+                                storeItems.Add(new StoreItem(jsonNode["ID"].AsInt, productIds++, count, currency, exchange, requireMission, jsonNode["storeId"].AsInt, chance));
                             }
                         }
                     }

--- a/CustomMerch/Patches.cs
+++ b/CustomMerch/Patches.cs
@@ -190,7 +190,7 @@ namespace CustomMerch
 
                     ___equipmentDataList.Add(equipConf);
 
-                    storeItems.Add(new StoreItem(itemIds, productIds++, 1, -1, "-1", item.storeId, item.chance));
+                    storeItems.Add(new StoreItem(itemIds, productIds++, 1, -1, "-1", "-1", item.storeId, item.chance));
 
                     itemIds++;
                     nameIds += 4;

--- a/CustomMerch/StoreItem.cs
+++ b/CustomMerch/StoreItem.cs
@@ -8,17 +8,18 @@ namespace CustomMerch
         public int productId;
         public int count;
         public int currency;
-        public DoubleInt exchange = new DoubleInt("-1",':');
+        public DoubleInt exchange;
         public int[] requireMissions;
         public float chance;
         public int storeId;
 
-        public StoreItem(int itemId, int productId, int count, int currency, string requireMission, int storeId, float chance = 1f)
+        public StoreItem(int itemId, int productId, int count, int currency, string exchange, string requireMission, int storeId, float chance = 1f)
         {
             this.itemId = itemId;
             this.productId = productId;
             this.count = count;
             this.currency = currency;
+            this.exchange = new DoubleInt(exchange, ':');
             string[] reqMissions = requireMission.Split(',');
             requireMissions = new int[reqMissions.Length];
             for (int i = 0; i < requireMissions.Length; i++)


### PR DESCRIPTION
Add exchange value to json.
Most of json field now is optional (only `ID` and `storeId` is required).
So you can write in config:
```
 {
  "ID":"3000218",
  "currency":"2060001",
  "exchange":"90",
  "storeId":"24",
 },
```
to add "3000218" item for 90 Data Disk.